### PR TITLE
Upgrade ruby versions and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
         include:
 #          - ruby: 2.3 # works
 #          - ruby: 2.4 # works
-          - ruby: 2.5 # dies
+#          - ruby: 2.5 # dies
 #          - ruby: 2.6
 #          - ruby: 2.7
+          - ruby: 3.1
 #          - ruby: 3.3
 #          - ruby: 3.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
 #          - ruby: 2.5 # dies
 #          - ruby: 2.6
 #          - ruby: 2.7
-          - ruby: 3.1
+#          - ruby: 3.1
+          - ruby: 3.2
 #          - ruby: 3.3
 #          - ruby: 3.4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: RSpec CI
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '*'
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: 'Ruby: ${{ matrix.ruby }}'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+#          - ruby: 2.3 # works
+#          - ruby: 2.4 # works
+          - ruby: 2.5 # dies
+#          - ruby: 2.6
+#          - ruby: 2.7
+#          - ruby: 3.3
+#          - ruby: 3.4
+
+    env: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rake spec
+        continue-on-error: ${{ matrix.allow_failure || false }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
 #          - ruby: 2.3 # works
 #          - ruby: 2.4 # works
 #          - ruby: 2.5 # dies
-#          - ruby: 2.6
-#          - ruby: 2.7
-#          - ruby: 3.1
-          - ruby: 3.2
+#          - ruby: 2.6 # eol
+#          - ruby: 2.7 # eol
+#          - ruby: 3.1 # eol
+#          - ruby: 3.2
 #          - ruby: 3.3
-#          - ruby: 3.4
+          - ruby: 3.4
 
     env: ${{ matrix.env }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - ruby: 2.3 # works
-#          - ruby: 2.4 # works
-#          - ruby: 2.5 # dies
-#          - ruby: 2.6 # eol
-#          - ruby: 2.7 # eol
-#          - ruby: 3.1 # eol
-#          - ruby: 3.2
-#          - ruby: 3.3
+          - ruby: 3.1 # eol
+          - ruby: 3.2
+          - ruby: 3.3
           - ruby: 3.4
 
     env: ${{ matrix.env }}

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in simplecov-markdown.gemspec
 gemspec
+gem 'bundler'
+gem 'coveralls'
+gem 'rake' # (~> 10.0)
+gem 'rspec'
+gem 'rspec-temp_dir' # (~> 0.0.3)
+gem 'simplecov-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     hirb (0.7.3)
-    json (2.0.2)
+    json (2.12.2)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   simplecov-markdown!
 
 BUNDLED WITH
-   1.12.5
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,57 +8,65 @@ GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
-    coveralls (0.8.15)
+    bigdecimal (3.2.2)
+    coveralls (0.8.23)
       json (>= 1.8, < 3)
-      simplecov (~> 0.12.0)
+      simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
-      tins (>= 1.6.0, < 2)
-    diff-lcs (1.2.5)
-    docile (1.1.5)
-    hirb (0.7.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
     json (2.12.2)
-    rake (10.5.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    rake (13.3.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.4)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    rspec-temp_dir (0.0.4)
-      rspec
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rspec-temp_dir (1.1.1)
+      rspec (>= 3.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-console (0.3.1)
+    simplecov-console (0.9.3)
       ansi
-      hirb
       simplecov
-    simplecov-html (0.10.0)
-    term-ansicolor (1.3.2)
+      terminal-table
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.11.2)
       tins (~> 1.0)
-    thor (0.19.1)
-    tins (1.12.0)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    thor (1.3.2)
+    tins (1.38.0)
+      bigdecimal
+      sync
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0)
+  bundler
   coveralls
-  rake (~> 10.0)
+  rake
   rspec
-  rspec-temp_dir (~> 0.0.3)
+  rspec-temp_dir
   simplecov-console
   simplecov-markdown!
 
 BUNDLED WITH
-   1.17.3
+   2.6.9

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Usage
 ----------------------------
 
 ```ruby
-require 'simplecov-csv'
+require 'simplecov-markdown'
 SimpleCov.formatter = SimpleCov::Formatter::MarkdownFormatter
 ```


### PR DESCRIPTION
Adds in a github action for a range of ruby versions so we can check that it runs in supported runtimes.

I've assumed that the coveralls isn't running any more.